### PR TITLE
add header/banner spec

### DIFF
--- a/example/browser.js
+++ b/example/browser.js
@@ -64,10 +64,12 @@ function fadeImg() {
   this.style.opacity = '1';
 }
 
-function setImage(ens, avatarUri = notFoundImage, warn = false) {
+function setImage(ens, avatarUri = notFoundImage, warn = false, headerUri) {
   const elem = document.getElementById('queryImage');
+  const headerContainer = document.getElementById('headerContainer');
   elem.setAttribute('src', avatarUri);
   elem.setAttribute('alt', ens);
+  headerContainer.style.backgroundImage = headerUri ? `url("${headerUri}")` : 'none';
   const warnText = document.getElementById('warnText');
   if (warn) {
     if (warnText) return;
@@ -112,7 +114,9 @@ document.getElementById('queryInput').addEventListener('change', event => {
     .getMetadata(ens)
     .then(metadata => {
       const avatar = avtUtils.getImageURI({ metadata });
-      setImage(ens, avatar);
+      avt.getHeader(ens).then(header => {
+        setImage(ens, avatar, false, header);
+      });
       elem.style.filter = 'none';
     })
     .catch(error => {

--- a/example/node.js
+++ b/example/node.js
@@ -15,7 +15,10 @@ const IPFS = 'https://cf-ipfs.com';
 const provider = new StaticJsonRpcProvider(
   `https://mainnet.infura.io/v3/${process.env.INFURA_KEY}`
 );
-const avt = new AvatarResolver(provider, { ipfs: IPFS, apiKey: { opensea: process.env.OPENSEA_KEY }});
+const avt = new AvatarResolver(provider, {
+  ipfs: IPFS,
+  apiKey: { opensea: process.env.OPENSEA_KEY },
+});
 avt
   .getMetadata(ensName)
   .then(metadata => {
@@ -30,6 +33,13 @@ avt
       },
       jsdomWindow: jsdom,
     });
-    console.log(avatar);
+    console.log('avatar: ', avatar);
+  })
+  .catch(console.log);
+
+avt
+  .getHeader(ensName)
+  .then(header => {
+    console.log('header: ', header);
   })
   .catch(console.log);

--- a/index.html
+++ b/index.html
@@ -9,20 +9,28 @@
     <div class="container">
       <div id="avatars"></div>
       <div class="queryContainer">
-        <h2>Query ENS Avatar</h2>
-        <div>
-          <img class="queryImage" id="queryImage" width="300" height="300" src="./example/ens.png" />
+        <div id="headerContainer">
+          <h2>Query ENS Avatar</h2>
           <div>
-            <input
-              class="queryInput"
-              id="queryInput"
-              type="text"
-              placeholder="vitalik.eth"
-              autofocus
-              autocomplete="off"
+            <img
+              class="queryImage"
+              id="queryImage"
+              width="300"
+              height="300"
+              src="./example/ens.png"
             />
-            <div class="hint">
-              (type ENS name and hit the enter button)
+            <div>
+              <input
+                class="queryInput"
+                id="queryInput"
+                type="text"
+                placeholder="vitalik.eth"
+                autofocus
+                autocomplete="off"
+              />
+              <div class="hint">
+                (type ENS name and hit the enter button)
+              </div>
             </div>
           </div>
         </div>
@@ -48,6 +56,12 @@
       overflow: hidden;
       pointer-events: none;
       user-select: none;
+    }
+    #headerContainer {
+      height: 100%;
+      background-position: 0 55px;
+      background-repeat: no-repeat;
+      background-size: contain;
     }
     .hint {
       margin-top: 0.5rem;
@@ -76,6 +90,9 @@
     }
     .queryImage {
       object-fit: contain;
+      border: 5px solid white;
+      border-radius: 5px;
+      outline: #d6d6d6 solid 2px;
     }
     .queryInput {
       width: 19rem;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
@@ -57,9 +57,11 @@
     "@size-limit/preset-small-lib": "^11.0.1",
     "@types/dompurify": "^3.0.5",
     "@types/jsdom": "^21.1.6",
+    "@types/moxios": "^0.4.17",
     "@types/url-join": "^4.0.1",
     "dotenv": "^16.3.1",
     "esbuild": "^0.14.21",
+    "moxios": "^0.4.0",
     "nock": "^13.2.2",
     "rollup": "^4.9.1",
     "size-limit": "^11.0.1",

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,11 @@ export interface AvatarRequestOpts {
   jsdomWindow?: any;
 }
 
+export interface HeaderRequestOpts {
+  jsdomWindow?: any;
+  mediaKey?: 'header' | 'banner';
+}
+
 export type Gateways = {
   ipfs?: string;
   arweave?: string;

--- a/src/utils/isImageURI.ts
+++ b/src/utils/isImageURI.ts
@@ -18,11 +18,11 @@ export const ALLOWED_IMAGE_MIMETYPES = [
 ];
 
 export const IMAGE_SIGNATURES = {
-  'FFD8FF': 'image/jpeg',
+  FFD8FF: 'image/jpeg',
   '89504E47': 'image/png',
   '47494638': 'image/gif',
   '424D': 'image/bmp',
-  'FF0A': 'image/jxl',
+  FF0A: 'image/jxl',
 };
 
 const MAX_FILE_SIZE = 300 * 1024 * 1024; // 300 MB

--- a/src/utils/isImageURI.ts
+++ b/src/utils/isImageURI.ts
@@ -4,6 +4,7 @@ import { Buffer } from 'buffer/';
 import { fetch } from './fetch';
 
 export const ALLOWED_IMAGE_MIMETYPES = [
+  'application/octet-stream',
   'image/jpeg',
   'image/png',
   'image/gif',
@@ -15,6 +16,14 @@ export const ALLOWED_IMAGE_MIMETYPES = [
   'image/heif',
   'image/jxl',
 ];
+
+export const IMAGE_SIGNATURES = {
+  'FFD8FF': 'image/jpeg',
+  '89504E47': 'image/png',
+  '47494638': 'image/gif',
+  '424D': 'image/bmp',
+  'FF0A': 'image/jxl',
+};
 
 const MAX_FILE_SIZE = 300 * 1024 * 1024; // 300 MB
 
@@ -56,19 +65,18 @@ async function isStreamAnImage(url: string): Promise<boolean> {
     if (response.data instanceof ArrayBuffer) {
       magicNumbers = new DataView(response.data).getUint32(0).toString(16);
     } else {
+      if (
+        !response.data ||
+        typeof response.data === 'string' ||
+        !('readUInt32BE' in response.data)
+      ) {
+        throw 'isStreamAnImage: unsupported data, instance is not BufferLike';
+      }
       magicNumbers = response.data.readUInt32BE(0).toString(16);
     }
 
-    const imageSignatures = [
-      'ffd8ff', // JPEG
-      '89504e47', // PNG
-      '47494638', // GIF
-      '424d', // BMP
-      'ff0a', // JPEG XL
-    ];
-
-    const isBinaryImage = imageSignatures.some(signature =>
-      magicNumbers.startsWith(signature)
+    const isBinaryImage = Object.keys(IMAGE_SIGNATURES).some(signature =>
+      magicNumbers.toUpperCase().startsWith(signature)
     );
 
     // Check for SVG image

--- a/test/resolver.test.ts
+++ b/test/resolver.test.ts
@@ -1,5 +1,5 @@
 import { JsonRpcProvider } from 'ethers';
-import nock from 'nock';
+import nock, { RequestBodyMatcher } from 'nock';
 import { AvatarResolver } from '../src';
 
 require('dotenv').config();
@@ -16,14 +16,14 @@ const CORS_HEADERS = {
 
 interface ChainIdParams {
   method: 'eth_chainId';
-  params: [];
+  params: Array<undefined>;
   id: number;
   jsonrpc: string;
 }
 
 interface EthCallParams {
   method: 'eth_call';
-  params: [{ to: string; data: string }, string];
+  params: Array<{ to: string; data: string } | string>;
   id: number;
   jsonrpc: string;
 }
@@ -35,12 +35,12 @@ interface JsonRpcResult {
 }
 
 function nockInfuraBatch(
-  body: Array<ChainIdParams | EthCallParams>,
+  body: Array<ChainIdParams | EthCallParams | null>,
   response: JsonRpcResult[]
 ) {
   nock(INFURA_URL.origin)
     .persist(false)
-    .post(INFURA_URL.pathname, body as [])
+    .post(INFURA_URL.pathname, body as RequestBodyMatcher)
     .reply(200, response);
 }
 

--- a/test/resolver.test.ts
+++ b/test/resolver.test.ts
@@ -14,19 +14,18 @@ const CORS_HEADERS = {
   'access-control-allow-origin': 'http://localhost',
 };
 
-
 interface ChainIdParams {
   method: 'eth_chainId';
   params: [];
   id: number;
-  jsonrpc: string,
+  jsonrpc: string;
 }
 
 interface EthCallParams {
-  method: 'eth_call',
-  params: [{ to: string, data: string }, string],
-  id: number,
-  jsonrpc: string,
+  method: 'eth_call';
+  params: [{ to: string; data: string }, string];
+  id: number;
+  jsonrpc: string;
 }
 
 interface JsonRpcResult {
@@ -35,7 +34,10 @@ interface JsonRpcResult {
   result: string;
 }
 
-function nockInfuraBatch(body: Array<ChainIdParams | EthCallParams>, response: JsonRpcResult[]) {
+function nockInfuraBatch(
+  body: Array<ChainIdParams | EthCallParams>,
+  response: JsonRpcResult[]
+) {
   nock(INFURA_URL.origin)
     .persist(false)
     .post(INFURA_URL.pathname, body as [])
@@ -61,7 +63,7 @@ function mockInfuraChainId() {
       },
       CORS_HEADERS as any
     );
-    nonceJsonRpc++;
+  nonceJsonRpc++;
 }
 
 function ethCallParams(to: string, data: string): EthCallParams {

--- a/test/resolver.test.ts
+++ b/test/resolver.test.ts
@@ -608,7 +608,6 @@ describe('get banner/header', () => {
       ]
     );
 
-
     const HEADER_URI_TANRIKULU = new URL(
       'https://ipfs.io/ipfs/QmUShgfoZQSHK3TQyuTfUpsc8UfeNfD8KwPUvDBUdZ4nmR'
     );

--- a/test/resolver.test.ts
+++ b/test/resolver.test.ts
@@ -14,14 +14,37 @@ const CORS_HEADERS = {
   'access-control-allow-origin': 'http://localhost',
 };
 
-function nockInfuraBatch(body: any[], response: any) {
+
+interface ChainIdParams {
+  method: 'eth_chainId';
+  params: [];
+  id: number;
+  jsonrpc: string,
+}
+
+interface EthCallParams {
+  method: 'eth_call',
+  params: [{ to: string, data: string }, string],
+  id: number,
+  jsonrpc: string,
+}
+
+interface JsonRpcResult {
+  jsonrpc: string;
+  id: number;
+  result: string;
+}
+
+function nockInfuraBatch(body: Array<ChainIdParams | EthCallParams>, response: JsonRpcResult[]) {
   nock(INFURA_URL.origin)
     .persist(false)
-    .post(INFURA_URL.pathname, body)
+    .post(INFURA_URL.pathname, body as [])
     .reply(200, response);
 }
 
-function mockInfuraChainId(id: number) {
+let nonceCall = 1,
+  nonceJsonRpc = 1;
+function mockInfuraChainId() {
   nock(INFURA_URL.origin)
     .post(INFURA_URL.pathname, {
       method: 'eth_chainId',
@@ -33,35 +56,36 @@ function mockInfuraChainId(id: number) {
       200,
       {
         jsonrpc: '2.0',
-        id: id,
+        id: nonceCall++,
         result: '0x1',
       },
       CORS_HEADERS as any
     );
+    nonceJsonRpc++;
 }
 
-function ethCallParams(to: string, data: string, id: number) {
+function ethCallParams(to: string, data: string): EthCallParams {
   return {
     method: 'eth_call',
     params: [{ to, data }, 'latest'],
-    id,
+    id: nonceCall++,
     jsonrpc: '2.0',
   };
 }
 
-function chainIdParams(id: number) {
+function chainIdParams(): ChainIdParams {
   return {
     method: 'eth_chainId',
     params: [],
-    id,
+    id: nonceCall++,
     jsonrpc: '2.0',
   };
 }
 
-function jsonRPCresult(result: string, id: number) {
+function jsonRpcResult(result: string): JsonRpcResult {
   return {
     jsonrpc: '2.0',
-    id,
+    id: nonceJsonRpc++,
     result,
   };
 }
@@ -74,31 +98,27 @@ describe('get avatar', () => {
     },
   });
   it('retrieves image uri with erc721 spec', async () => {
-    mockInfuraChainId(1);
+    mockInfuraChainId();
 
     nockInfuraBatch(
       [
-        chainIdParams(2),
+        chainIdParams(),
         ethCallParams(
           ENSRegistryWithFallback,
-          '0x0178b8bf80ee077a908dffcf32972ba13c2df16b42688e1de21bcf17d3469a8507895eae',
-          3
+          '0x0178b8bf80ee077a908dffcf32972ba13c2df16b42688e1de21bcf17d3469a8507895eae'
         ),
         ethCallParams(
           ENSRegistryWithFallback,
-          '0x0178b8bf80ee077a908dffcf32972ba13c2df16b42688e1de21bcf17d3469a8507895eae',
-          4
+          '0x0178b8bf80ee077a908dffcf32972ba13c2df16b42688e1de21bcf17d3469a8507895eae'
         ),
       ],
       [
-        jsonRPCresult('0x1', 2),
-        jsonRPCresult(
-          '0x0000000000000000000000004976fb03c32e5b8cfe2b6ccb31c09ba78ebaba41',
-          3
+        jsonRpcResult('0x1'),
+        jsonRpcResult(
+          '0x0000000000000000000000004976fb03c32e5b8cfe2b6ccb31c09ba78ebaba41'
         ),
-        jsonRPCresult(
-          '0x0000000000000000000000004976fb03c32e5b8cfe2b6ccb31c09ba78ebaba41',
-          4
+        jsonRpcResult(
+          '0x0000000000000000000000004976fb03c32e5b8cfe2b6ccb31c09ba78ebaba41'
         ),
       ]
     );
@@ -106,93 +126,81 @@ describe('get avatar', () => {
       [
         ethCallParams(
           PublicResolver.toLowerCase(),
-          '0x01ffc9a79061b92300000000000000000000000000000000000000000000000000000000',
-          5
+          '0x01ffc9a79061b92300000000000000000000000000000000000000000000000000000000'
         ),
-        chainIdParams(6),
+        chainIdParams(),
       ],
       [
-        jsonRPCresult(
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          5
+        jsonRpcResult(
+          '0x0000000000000000000000000000000000000000000000000000000000000000'
         ),
-        jsonRPCresult('0x1', 6),
+        jsonRpcResult('0x1'),
       ]
     );
     nockInfuraBatch(
       [
         ethCallParams(
           PublicResolver.toLowerCase(),
-          '0x3b3b57de80ee077a908dffcf32972ba13c2df16b42688e1de21bcf17d3469a8507895eae',
-          7
+          '0x3b3b57de80ee077a908dffcf32972ba13c2df16b42688e1de21bcf17d3469a8507895eae'
         ),
-        chainIdParams(8),
+        chainIdParams(),
       ],
       [
-        jsonRPCresult(
-          '0x0000000000000000000000005a384227b65fa093dec03ec34e111db80a040615',
-          7
+        jsonRpcResult(
+          '0x0000000000000000000000005a384227b65fa093dec03ec34e111db80a040615'
         ),
-        jsonRPCresult('0x1', 8),
+        jsonRpcResult('0x1'),
       ]
     );
     nockInfuraBatch(
       [
         ethCallParams(
           PublicResolver.toLowerCase(),
-          '0x01ffc9a79061b92300000000000000000000000000000000000000000000000000000000',
-          9
+          '0x01ffc9a79061b92300000000000000000000000000000000000000000000000000000000'
         ),
-        chainIdParams(10),
+        chainIdParams(),
       ],
       [
-        jsonRPCresult(
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          9
+        jsonRpcResult(
+          '0x0000000000000000000000000000000000000000000000000000000000000000'
         ),
-        jsonRPCresult('0x1', 10),
+        jsonRpcResult('0x1'),
       ]
     );
     nockInfuraBatch(
       [
         ethCallParams(
           PublicResolver.toLowerCase(),
-          '0x59d1d43c80ee077a908dffcf32972ba13c2df16b42688e1de21bcf17d3469a8507895eae000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000066176617461720000000000000000000000000000000000000000000000000000',
-          11
+          '0x59d1d43c80ee077a908dffcf32972ba13c2df16b42688e1de21bcf17d3469a8507895eae000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000066176617461720000000000000000000000000000000000000000000000000000'
         ),
-        chainIdParams(12),
+        chainIdParams(),
       ],
       [
-        jsonRPCresult(
-          '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003f6569703135353a312f6572633732313a3078333133383564333532306263656439346637376161653130346234303639393464386632313638632f3934323100',
-          11
+        jsonRpcResult(
+          '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003f6569703135353a312f6572633732313a3078333133383564333532306263656439346637376161653130346234303639393464386632313638632f3934323100'
         ),
-        jsonRPCresult('0x1', 12),
+        jsonRpcResult('0x1'),
       ]
     );
     nockInfuraBatch(
       [
         ethCallParams(
           '0x31385d3520bced94f77aae104b406994d8f2168c',
-          '0xc87b56dd00000000000000000000000000000000000000000000000000000000000024cd',
-          13
+          '0xc87b56dd00000000000000000000000000000000000000000000000000000000000024cd'
         ),
-        chainIdParams(14),
+        chainIdParams(),
         ethCallParams(
           '0x31385d3520bced94f77aae104b406994d8f2168c',
-          '0x6352211e00000000000000000000000000000000000000000000000000000000000024cd',
-          15
+          '0x6352211e00000000000000000000000000000000000000000000000000000000000024cd'
         ),
       ],
       [
-        jsonRPCresult(
-          '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002568747470733a2f2f6170692e6261737461726467616e70756e6b732e636c75622f39343231000000000000000000000000000000000000000000000000000000',
-          13
+        jsonRpcResult(
+          '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002568747470733a2f2f6170692e6261737461726467616e70756e6b732e636c75622f39343231000000000000000000000000000000000000000000000000000000'
         ),
-        jsonRPCresult('0x1', 14),
-        jsonRPCresult(
-          '0x0000000000000000000000005a384227b65fa093dec03ec34e111db80a040615',
-          15
+        jsonRpcResult('0x1'),
+        jsonRpcResult(
+          '0x0000000000000000000000005a384227b65fa093dec03ec34e111db80a040615'
         ),
       ]
     );
@@ -231,31 +239,27 @@ describe('get avatar', () => {
     );
   });
   it('retrieves image uri with custom spec', async () => {
-    mockInfuraChainId(16);
+    mockInfuraChainId();
 
     nockInfuraBatch(
       [
         ethCallParams(
           ENSRegistryWithFallback.toString(),
-          '0x0178b8bfb47a0edaf3c702800c923ca4c44a113d0d718cb1f42ecdce70c5fd05fa36a63f',
-          17
+          '0x0178b8bfb47a0edaf3c702800c923ca4c44a113d0d718cb1f42ecdce70c5fd05fa36a63f'
         ),
-        chainIdParams(18),
+        chainIdParams(),
         ethCallParams(
           ENSRegistryWithFallback.toString(),
-          '0x0178b8bfb47a0edaf3c702800c923ca4c44a113d0d718cb1f42ecdce70c5fd05fa36a63f',
-          19
+          '0x0178b8bfb47a0edaf3c702800c923ca4c44a113d0d718cb1f42ecdce70c5fd05fa36a63f'
         ),
       ],
       [
-        jsonRPCresult(
-          '0x0000000000000000000000004976fb03c32e5b8cfe2b6ccb31c09ba78ebaba41',
-          17
+        jsonRpcResult(
+          '0x0000000000000000000000004976fb03c32e5b8cfe2b6ccb31c09ba78ebaba41'
         ),
-        jsonRPCresult('0x1', 18),
-        jsonRPCresult(
-          '0x0000000000000000000000004976fb03c32e5b8cfe2b6ccb31c09ba78ebaba41',
-          19
+        jsonRpcResult('0x1'),
+        jsonRpcResult(
+          '0x0000000000000000000000004976fb03c32e5b8cfe2b6ccb31c09ba78ebaba41'
         ),
       ]
     );
@@ -263,68 +267,60 @@ describe('get avatar', () => {
       [
         ethCallParams(
           PublicResolver.toLowerCase(),
-          '0x01ffc9a79061b92300000000000000000000000000000000000000000000000000000000',
-          20
+          '0x01ffc9a79061b92300000000000000000000000000000000000000000000000000000000'
         ),
-        chainIdParams(21),
+        chainIdParams(),
       ],
       [
-        jsonRPCresult(
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          20
+        jsonRpcResult(
+          '0x0000000000000000000000000000000000000000000000000000000000000000'
         ),
-        jsonRPCresult('0x1', 21),
+        jsonRpcResult('0x1'),
       ]
     );
     nockInfuraBatch(
       [
         ethCallParams(
           PublicResolver.toLowerCase(),
-          '0x3b3b57deb47a0edaf3c702800c923ca4c44a113d0d718cb1f42ecdce70c5fd05fa36a63f',
-          22
+          '0x3b3b57deb47a0edaf3c702800c923ca4c44a113d0d718cb1f42ecdce70c5fd05fa36a63f'
         ),
-        chainIdParams(23),
+        chainIdParams(),
       ],
       [
-        jsonRPCresult(
-          '0x0000000000000000000000000d59d0f7dcc0fbf0a3305ce0261863aaf7ab685c',
-          22
+        jsonRpcResult(
+          '0x0000000000000000000000000d59d0f7dcc0fbf0a3305ce0261863aaf7ab685c'
         ),
-        jsonRPCresult('0x1', 23),
+        jsonRpcResult('0x1'),
       ]
     );
     nockInfuraBatch(
       [
         ethCallParams(
           PublicResolver.toLowerCase(),
-          '0x01ffc9a79061b92300000000000000000000000000000000000000000000000000000000',
-          24
+          '0x01ffc9a79061b92300000000000000000000000000000000000000000000000000000000'
         ),
-        chainIdParams(25),
+        chainIdParams(),
       ],
       [
-        jsonRPCresult(
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          24
+        jsonRpcResult(
+          '0x0000000000000000000000000000000000000000000000000000000000000000'
         ),
-        jsonRPCresult('0x1', 25),
+        jsonRpcResult('0x1'),
       ]
     );
     nockInfuraBatch(
       [
         ethCallParams(
           PublicResolver.toLowerCase(),
-          '0x59d1d43cb47a0edaf3c702800c923ca4c44a113d0d718cb1f42ecdce70c5fd05fa36a63f000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000066176617461720000000000000000000000000000000000000000000000000000',
-          26
+          '0x59d1d43cb47a0edaf3c702800c923ca4c44a113d0d718cb1f42ecdce70c5fd05fa36a63f000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000066176617461720000000000000000000000000000000000000000000000000000'
         ),
-        chainIdParams(27),
+        chainIdParams(),
       ],
       [
-        jsonRPCresult(
-          '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004368747470733a2f2f697066732e696f2f697066732f516d55536867666f5a5153484b3354517975546655707363385566654e6644384b77505576444255645a346e6d520000000000000000000000000000000000000000000000000000000000',
-          26
+        jsonRpcResult(
+          '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004368747470733a2f2f697066732e696f2f697066732f516d55536867666f5a5153484b3354517975546655707363385566654e6644384b77505576444255645a346e6d520000000000000000000000000000000000000000000000000000000000'
         ),
-        jsonRPCresult('0x1', 27),
+        jsonRpcResult('0x1'),
       ]
     );
     const MANIFEST_URI_TANRIKULU = new URL(
@@ -349,31 +345,27 @@ describe('get avatar', () => {
     );
   });
   it('retrieves image uri with erc1155 spec', async () => {
-    mockInfuraChainId(28);
+    mockInfuraChainId();
 
     nockInfuraBatch(
       [
         ethCallParams(
           ENSRegistryWithFallback.toLowerCase(),
-          '0x0178b8bf05a67c0ee82964c4f7394cdd47fee7f4d9503a23c09c38341779ea012afe6e00',
-          29
+          '0x0178b8bf05a67c0ee82964c4f7394cdd47fee7f4d9503a23c09c38341779ea012afe6e00'
         ),
-        chainIdParams(30),
+        chainIdParams(),
         ethCallParams(
           ENSRegistryWithFallback.toLowerCase(),
-          '0x0178b8bf05a67c0ee82964c4f7394cdd47fee7f4d9503a23c09c38341779ea012afe6e00',
-          31
+          '0x0178b8bf05a67c0ee82964c4f7394cdd47fee7f4d9503a23c09c38341779ea012afe6e00'
         ),
       ],
       [
-        jsonRPCresult(
-          '0x0000000000000000000000004976fb03c32e5b8cfe2b6ccb31c09ba78ebaba41',
-          29
+        jsonRpcResult(
+          '0x0000000000000000000000004976fb03c32e5b8cfe2b6ccb31c09ba78ebaba41'
         ),
-        jsonRPCresult('0x1', 30),
-        jsonRPCresult(
-          '0x0000000000000000000000004976fb03c32e5b8cfe2b6ccb31c09ba78ebaba41',
-          31
+        jsonRpcResult('0x1'),
+        jsonRpcResult(
+          '0x0000000000000000000000004976fb03c32e5b8cfe2b6ccb31c09ba78ebaba41'
         ),
       ]
     );
@@ -381,93 +373,81 @@ describe('get avatar', () => {
       [
         ethCallParams(
           PublicResolver.toLowerCase(),
-          '0x01ffc9a79061b92300000000000000000000000000000000000000000000000000000000',
-          32
+          '0x01ffc9a79061b92300000000000000000000000000000000000000000000000000000000'
         ),
-        chainIdParams(33),
+        chainIdParams(),
       ],
       [
-        jsonRPCresult(
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          32
+        jsonRpcResult(
+          '0x0000000000000000000000000000000000000000000000000000000000000000'
         ),
-        jsonRPCresult('0x1', 33),
+        jsonRpcResult('0x1'),
       ]
     );
     nockInfuraBatch(
       [
         ethCallParams(
           PublicResolver.toLowerCase(),
-          '0x3b3b57de05a67c0ee82964c4f7394cdd47fee7f4d9503a23c09c38341779ea012afe6e00',
-          34
+          '0x3b3b57de05a67c0ee82964c4f7394cdd47fee7f4d9503a23c09c38341779ea012afe6e00'
         ),
-        chainIdParams(35),
+        chainIdParams(),
       ],
       [
-        jsonRPCresult(
-          '0x000000000000000000000000b8c2c29ee19d8307cb7255e1cd9cbde883a267d5',
-          34
+        jsonRpcResult(
+          '0x000000000000000000000000b8c2c29ee19d8307cb7255e1cd9cbde883a267d5'
         ),
-        jsonRPCresult('0x1', 35),
+        jsonRpcResult('0x1'),
       ]
     );
     nockInfuraBatch(
       [
         ethCallParams(
           PublicResolver.toLowerCase(),
-          '0x01ffc9a79061b92300000000000000000000000000000000000000000000000000000000',
-          36
+          '0x01ffc9a79061b92300000000000000000000000000000000000000000000000000000000'
         ),
-        chainIdParams(37),
+        chainIdParams(),
       ],
       [
-        jsonRPCresult(
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-          36
+        jsonRpcResult(
+          '0x0000000000000000000000000000000000000000000000000000000000000000'
         ),
-        jsonRPCresult('0x1', 37),
+        jsonRpcResult('0x1'),
       ]
     );
     nockInfuraBatch(
       [
         ethCallParams(
           PublicResolver.toLowerCase(),
-          '0x59d1d43c05a67c0ee82964c4f7394cdd47fee7f4d9503a23c09c38341779ea012afe6e00000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000066176617461720000000000000000000000000000000000000000000000000000',
-          38
+          '0x59d1d43c05a67c0ee82964c4f7394cdd47fee7f4d9503a23c09c38341779ea012afe6e00000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000066176617461720000000000000000000000000000000000000000000000000000'
         ),
-        chainIdParams(39),
+        chainIdParams(),
       ],
       [
-        jsonRPCresult(
-          '0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000886569703135353a312f657263313135353a3078343935663934373237363734396365363436663638616338633234383432303034356362376235652f38313132333136303235383733393237373337353035393337383938393135313533373332353830313033393133373034333334303438353132333830343930373937303038353531393337000000000000000000000000000000000000000000000000',
-          38
+        jsonRpcResult(
+          '0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000886569703135353a312f657263313135353a3078343935663934373237363734396365363436663638616338633234383432303034356362376235652f38313132333136303235383733393237373337353035393337383938393135313533373332353830313033393133373034333334303438353132333830343930373937303038353531393337000000000000000000000000000000000000000000000000'
         ),
-        jsonRPCresult('0x1', 39),
+        jsonRpcResult('0x1'),
       ]
     );
     nockInfuraBatch(
       [
         ethCallParams(
           '0x495f947276749ce646f68ac8c248420045cb7b5e',
-          '0x0e89341c11ef687cfeb2e353670479f2dcc76af2bc6b3935000000000002c40000000001',
-          40
+          '0x0e89341c11ef687cfeb2e353670479f2dcc76af2bc6b3935000000000002c40000000001'
         ),
-        chainIdParams(41),
+        chainIdParams(),
         ethCallParams(
           '0x495f947276749ce646f68ac8c248420045cb7b5e',
-          '0x00fdd58e000000000000000000000000b8c2c29ee19d8307cb7255e1cd9cbde883a267d511ef687cfeb2e353670479f2dcc76af2bc6b3935000000000002c40000000001',
-          42
+          '0x00fdd58e000000000000000000000000b8c2c29ee19d8307cb7255e1cd9cbde883a267d511ef687cfeb2e353670479f2dcc76af2bc6b3935000000000002c40000000001'
         ),
       ],
       [
-        jsonRPCresult(
-          '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000005868747470733a2f2f6170692e6f70656e7365612e696f2f6170692f76312f6d657461646174612f3078343935663934373237363734394365363436663638414338633234383432303034356362376235652f30787b69647d0000000000000000',
-          40
+        jsonRpcResult(
+          '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000005868747470733a2f2f6170692e6f70656e7365612e696f2f6170692f76312f6d657461646174612f3078343935663934373237363734394365363436663638414338633234383432303034356362376235652f30787b69647d0000000000000000'
         ),
-        jsonRPCresult('0x1', 41),
-        jsonRPCresult(
-          '0x0000000000000000000000000000000000000000000000000000000000000001',
-          42
+        jsonRpcResult('0x1'),
+        jsonRpcResult(
+          '0x0000000000000000000000000000000000000000000000000000000000000001'
         ),
       ]
     );

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,8 +1,13 @@
+import { JSDOM } from 'jsdom';
+import moxios from 'moxios';
+import { fetch } from '../src/utils';
 import { CID } from 'multiformats/cid';
 import {
+  ALLOWED_IMAGE_MIMETYPES,
   assert,
   BaseError,
   isCID,
+  isImageURI,
   parseNFT,
   resolveURI,
   getImageURI,
@@ -24,6 +29,7 @@ describe('resolve ipfs', () => {
     'ipns/QmZHKZDavkvNfA9gSAg7HALv8jF7BJaKjUc9U2LSuvUySB/1.json',
     'ipns/ipns.com',
     '/ipns/github.com',
+    'https://ipfs.io/ipfs/QmZHKZDavkvNfA9gSAg7HALv8jF7BJaKjUc9U2LSuvUySB',
   ];
 
   const arweaveCases = [
@@ -50,6 +56,13 @@ describe('resolve ipfs', () => {
     for (let uri of arweaveCases) {
       const { uri: resolvedURI } = resolveURI(uri);
       expect(resolvedURI).toMatch(/^https:\/\/arweave.net\/?/);
+    }
+  });
+
+  it('resolve different ipfs uri cases with custom gateway', () => {
+    for (let uri of ipfsCases) {
+      const { uri: resolvedURI } = resolveURI(uri, { ipfs: 'https://custom-ipfs.io' });
+      expect(resolvedURI).toMatch(/^https:\/\/custom-ipfs.io\/?/);
     }
   });
 
@@ -195,3 +208,314 @@ describe('remove refresh meta tags', () => {
     expect(result).toBe(sanitizedBase64svg);
   });
 });
+
+describe('getImageURI', () => {
+  const jsdomWindow = new JSDOM().window;
+
+  it('should throw an error when image is not available', () => {
+    expect(() => getImageURI({ metadata: {}, jsdomWindow })).toThrow(
+      'Image is not available'
+    );
+  });
+
+  it('should handle image_url', () => {
+    const result = getImageURI({
+      metadata: { image_url: 'https://example.com/image.png' },
+      jsdomWindow,
+    });
+    expect(result).toBe('https://example.com/image.png');
+  });
+
+  it('should handle image_data', () => {
+    const svgData =
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect width="100" height="100"/></svg>';
+    const result = getImageURI({
+      metadata: { image_data: svgData },
+      jsdomWindow,
+    });
+    expect(result).toMatch(/^data:image\/svg\+xml;base64,/);
+  });
+
+  it('should sanitize SVG content', () => {
+    const maliciousSVG =
+      '<svg xmlns="http://www.w3.org/2000/svg"><script>alert("XSS")</script></svg>';
+    const result = getImageURI({
+      metadata: { image: maliciousSVG },
+      jsdomWindow,
+    });
+    expect(result).not.toContain('<script>');
+  });
+
+  it('should handle base64 encoded SVG', () => {
+    const base64SVG =
+      'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxyZWN0IGhlaWdodD0iMTAwIiB3aWR0aD0iMTAwIj48L3JlY3Q+PC9zdmc+';
+    const result = getImageURI({ metadata: { image: base64SVG }, jsdomWindow });
+    if (!result) throw 'No result';
+    expect(result).toMatch(/^data:image\/svg\+xml;base64,/);
+    expect(compareSVGs(base64SVG, result)).toBe(true);
+  });
+
+  it('should handle non-SVG data URIs', () => {
+    const pngDataURI =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==';
+    const result = getImageURI({
+      metadata: { image: pngDataURI },
+      jsdomWindow,
+    });
+    expect(result).toBe(pngDataURI);
+  });
+
+  it('should return null for URL encoded SVG', () => {
+    const urlEncodedSVG =
+      'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Crect%20width%3D%22100%22%20height%3D%22100%22%2F%3E%3C%2Fsvg%3E';
+    const result = getImageURI({
+      metadata: { image: urlEncodedSVG },
+      jsdomWindow,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('should return null for invalid data URIs', () => {
+    const invalidDataURI = 'data:image/invalid,somedata';
+    const result = getImageURI({
+      metadata: { image: invalidDataURI },
+      jsdomWindow,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('should handle HTTP URLs', () => {
+    const httpURL = 'http://example.com/image.jpg';
+    const result = getImageURI({ metadata: { image: httpURL }, jsdomWindow });
+    expect(result).toBe(httpURL);
+  });
+
+  it('should return null for URLs in denyList', () => {
+    const deniedURL = 'https://malicious.com/image.jpg';
+    const result = getImageURI({
+      metadata: { image: deniedURL },
+      jsdomWindow,
+      urlDenyList: ['malicious.com'],
+    });
+    expect(result).toBeNull();
+  });
+
+  it('should handle custom gateways', () => {
+    const ipfsHash = 'ipfs://QmUShgfoZQSHK3TQyuTfUpsc8UfeNfD8KwPUvDBUdZ4nmR';
+    const customGateway = 'https://custom-gateway.com/';
+    const result = getImageURI({
+      metadata: { image: ipfsHash },
+      jsdomWindow,
+      customGateway,
+    });
+    expect(result).toBe(
+      'https://custom-gateway.com/ipfs/QmUShgfoZQSHK3TQyuTfUpsc8UfeNfD8KwPUvDBUdZ4nmR'
+    );
+  });
+
+  it('should return null for unsupported protocols', () => {
+    const ftpURL = 'ftp://example.com/image.jpg';
+    const result = getImageURI({ metadata: { image: ftpURL }, jsdomWindow });
+    expect(result).toBeNull();
+  });
+
+  it('should handle errors in base64 decoding', () => {
+    const invalidBase64 = 'data:image/svg+xml;base64,Invalid Base64!!!';
+    const result = getImageURI({ metadata: { image: invalidBase64 }, jsdomWindow });
+    expect(result).toBeNull();
+  });
+
+  it('should handle errors in URL decoding', () => {
+    const invalidURLEncoded = 'data:image/svg+xml,%Invalid URL encoding!!!';
+    const result = getImageURI({
+      metadata: { image: invalidURLEncoded },
+      jsdomWindow,
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe('isImageURI', () => {
+  beforeEach(() => {
+    moxios.install(fetch as any);
+  });
+
+  afterEach(() => {
+    moxios.uninstall(fetch as any);
+  });
+
+  ALLOWED_IMAGE_MIMETYPES.forEach(mimeType => {
+    it(`should return true for ${mimeType}`, async () => {
+      moxios.stubRequest(/.*/, {
+        status: 200,
+        headers: {
+          'Content-Type': mimeType,
+          'Content-Length': '1000',
+        },
+        ...(mimeType === ALLOWED_IMAGE_MIMETYPES[0] && {
+          // application/octet-stream
+          // JPEG magic numbers
+          response: Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
+        }),
+      });
+
+      const result = await isImageURI('https://example.com/image');
+      expect(result).toBe(true);
+    });
+  });
+
+  it('should return false for non-image content types', async () => {
+    moxios.stubRequest(/.*/, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/html',
+        'Content-Length': '1000',
+      },
+    });
+
+    const result = await isImageURI('https://example.com/not-an-image');
+    expect(result).toBe(false);
+  });
+
+  it('should return false for files larger than MAX_FILE_SIZE', async () => {
+    moxios.stubRequest(/.*/, {
+      status: 200,
+      headers: {
+        'Content-Type': 'image/jpeg',
+        'Content-Length': (300 * 1024 * 1024 + 1).toString(),
+      },
+    });
+
+    const result = await isImageURI('https://example.com/large-image');
+    expect(result).toBe(false);
+  });
+
+  it('should handle URI encoded URLs', async () => {
+    moxios.stubRequest(/.*/, {
+      status: 200,
+      headers: {
+        'Content-Type': 'image/jpeg',
+        'Content-Length': '1000',
+      },
+    });
+
+    const result = await isImageURI(
+      'https://example.com/image%20with%20spaces'
+    );
+    expect(result).toBe(true);
+  });
+
+  it('should check stream for application/octet-stream content type', async () => {
+    moxios.stubRequest(/.*/, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/octet-stream',
+        'Content-Length': '1000',
+      },
+      response: Buffer.from([0xff, 0xd8, 0xff, 0xe0, ...Buffer.alloc(8)]), // JPEG magic numbers
+    });
+
+    const result = await isImageURI(
+      'https://example.com/image-as-octet-stream'
+    );
+    expect(result).toBe(true);
+  });
+
+  it('should return false for non-image streams', async () => {
+    moxios.stubRequest(/.*/, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/octet-stream',
+        'Content-Length': '1000',
+      },
+      response: Buffer.from([0x00, 0x00, 0x00, 0x00, ...Buffer.alloc(8)]), // Non-image magic numbers
+    });
+
+    const result = await isImageURI('https://example.com/not-an-image-stream');
+    expect(result).toBe(false);
+  });
+
+  it('should handle network errors', async () => {
+    moxios.stubRequest(/.*/, {
+      status: 500,
+      response: 'Network error',
+    });
+
+    const result = await isImageURI('https://example.com/network-error');
+    expect(result).toBe(false);
+  });
+
+  it('should return false when content-type header is missing', async () => {
+    moxios.stubRequest(/.*/, {
+      status: 200,
+      response: '',
+      headers: {
+        'Content-Length': '1000',
+      },
+    });
+
+    const result = await isImageURI('https://example.com/no-content-type');
+    expect(result).toBe(false);
+  });
+
+  it('should return false for non-200 status codes', async () => {
+    moxios.stubRequest(/.*/, {
+      status: 404,
+      response: 'Not Found',
+    });
+
+    const result = await isImageURI('https://example.com/not-found');
+    expect(result).toBe(false);
+  });
+
+  it('should handle errors in isStreamAnImage', async () => {
+    moxios.stubRequest(/.*/, {
+      status: 200,
+      response: 'Invalid image data',
+      headers: {
+        'Content-Type': 'application/octet-stream',
+        'Content-Length': '1000',
+      },
+    });
+
+    const result = await isImageURI('https://example.com/invalid-image-stream');
+    expect(result).toBe(false);
+  });
+
+  it('should return false when SVG content under application/octet-stream', async () => {
+    const svgContent =
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect width="100" height="100"/></svg>';
+    moxios.stubRequest(/.*/, {
+      status: 200,
+      response: svgContent,
+      headers: {
+        'Content-Type': 'application/octet-stream',
+        'Content-Length': svgContent.length.toString(),
+      },
+    });
+
+    const result = await isImageURI('https://example.com/svg-image');
+    expect(result).toBe(false);
+  });
+});
+
+function compareSVGs(svg1: string, svg2: string) {
+  const parser = new DOMParser();
+  const parseSVG = (svg: string) => {
+    const doc = parser.parseFromString(svg, 'image/svg+xml');
+    const rect = doc.getElementsByTagName('rect')[0];
+    return {
+      width: rect.getAttribute('width'),
+      height: rect.getAttribute('height'),
+    };
+  };
+
+  const parsed1 = parseSVG(
+    Buffer.from(svg1.split(',')[1], 'base64').toString()
+  );
+  const parsed2 = parseSVG(
+    Buffer.from(svg2.split(',')[1], 'base64').toString()
+  );
+
+  return JSON.stringify(parsed1) === JSON.stringify(parsed2);
+}

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -61,7 +61,9 @@ describe('resolve ipfs', () => {
 
   it('resolve different ipfs uri cases with custom gateway', () => {
     for (let uri of ipfsCases) {
-      const { uri: resolvedURI } = resolveURI(uri, { ipfs: 'https://custom-ipfs.io' });
+      const { uri: resolvedURI } = resolveURI(uri, {
+        ipfs: 'https://custom-ipfs.io',
+      });
       expect(resolvedURI).toMatch(/^https:\/\/custom-ipfs.io\/?/);
     }
   });
@@ -321,7 +323,10 @@ describe('getImageURI', () => {
 
   it('should handle errors in base64 decoding', () => {
     const invalidBase64 = 'data:image/svg+xml;base64,Invalid Base64!!!';
-    const result = getImageURI({ metadata: { image: invalidBase64 }, jsdomWindow });
+    const result = getImageURI({
+      metadata: { image: invalidBase64 },
+      jsdomWindow,
+    });
     expect(result).toBeNull();
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "module": "esnext",
     "lib": ["dom", "esnext"],
+    "target": "ES2018",
     "importHelpers": true,
     // output .d.ts declaration files for consumers
     "declaration": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1800,6 +1800,13 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/moxios@^0.4.17":
+  version "0.4.17"
+  resolved "https://registry.yarnpkg.com/@types/moxios/-/moxios-0.4.17.tgz#3a2084b9b11713dde0da8c681db642936d3edf40"
+  integrity sha512-Ef7VE+vfISBbxWMOl40doJpHGpy5lTYJQwWHAy9ah1lrRnsVd+eNt6NjJ2QTAotHpQ7krVrZ3lp8hnxUxvdGuw==
+  dependencies:
+    axios ">=0.13.0"
+
 "@types/node@*":
   version "17.0.10"
   resolved "https://registry.npmjs.org/@types/node/-/node-17.0.10.tgz"
@@ -2172,6 +2179,15 @@ axios-cache-interceptor@^0.9.3:
     cache-parser "^1.2.2"
     fast-defer "^1.1.5"
     object-code "^1.2.0"
+
+axios@>=0.13.0:
+  version "1.7.7"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.7.tgz#2f554296f9892a72ac8d8e4c5b79c14a91d0a47f"
+  integrity sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axios@^0.27.2:
   version "0.27.2"
@@ -3724,6 +3740,11 @@ follow-redirects@^1.14.9:
   version "1.15.3"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
   integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
+
+follow-redirects@^1.15.6:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -5402,6 +5423,11 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+moxios@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/moxios/-/moxios-0.4.0.tgz#fc0da2c65477d725ca6b9679d58370ed0c52f53b"
+  integrity sha512-r+7DOsTcoTAwY6TGIDtjeTEBXMW8aGgk74MfASOC1tgYXD8Kq+cnqQHUdMnvfjf/CK7Pg/Wo52ohqy5zlyv9XQ==
+
 mri@^1.1.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz"
@@ -5943,6 +5969,11 @@ propagate@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz"
   integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.28:
   version "1.8.0"


### PR DESCRIPTION
the PR introduces `getHeader` method to retrieve ens headers/banners, based on the  [same spec](https://github.com/ensdomains/ens-avatar/pull/50) written for the avatar text record.

Method interface;
```ts
interface HeaderRequestOpts {
  jsdomWindow?: any;                 // required for any environment other than browser
  mediaKey?: 'header' | 'banner';    // both "header" and "banner" text records are supported. (default: header)
}

getHeader(ens: string, data: HeaderRequestOpts): Promise<string | null>;
```

